### PR TITLE
Optimize ExampleNode.

### DIFF
--- a/conspectus/src/main/kotlin/conspectus/engine/ExampleGroupNode.kt
+++ b/conspectus/src/main/kotlin/conspectus/engine/ExampleGroupNode.kt
@@ -44,7 +44,7 @@ internal class ExampleGroupNode(
     override fun example(name: String, marker: Marker?, action: Example.() -> Unit) {
         val id = uniqueId.childId(ExampleNode.TYPE, name)
 
-        appendChild(ExampleNode(id, name, null, marker.nested(this.marker), action))
+        appendChild(ExampleNode(id, name, marker.nested(this.marker), action))
     }
 
     private fun appendChild(child: TestDescriptor) {

--- a/conspectus/src/test/kotlin/conspectus/engine/ExampleNodeSpec.kt
+++ b/conspectus/src/test/kotlin/conspectus/engine/ExampleNodeSpec.kt
@@ -3,7 +3,6 @@ package conspectus.engine
 import conspectus.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.platform.engine.UniqueId
-import org.junit.platform.engine.support.descriptor.ClassSource
 import org.mockito.Mockito
 
 class ExampleNodeSpec : Spec({
@@ -60,15 +59,15 @@ class ExampleNodeSpec : Spec({
 }) {
 
     class Environment {
+
         companion object {
             private val ID = UniqueId.root("node", "node")
-            private val SOURCE = ClassSource.from(ExampleNodeSpec::class.java)
         }
 
         val nodeGrandParentBeforeEach = mock<() -> Unit>()
         val nodeGrandParentAfterEach = mock<() -> Unit>()
 
-        private val nodeGrandParent = (ExampleGroupNode(ID, "Node grandparent", SOURCE) {}).apply {
+        private val nodeGrandParent = (ExampleGroupNode(ID, "Node grandparent", null) {}).apply {
             beforeEach(nodeGrandParentBeforeEach)
             afterEach(nodeGrandParentAfterEach)
         }
@@ -76,13 +75,13 @@ class ExampleNodeSpec : Spec({
         val nodeParentBeforeEach = mock<() -> Unit>()
         val nodeParentAfterEach = mock<() -> Unit>()
 
-        private val nodeParent = (ExampleGroupNode(ID, "Node parent", SOURCE) {}).apply {
+        private val nodeParent = (ExampleGroupNode(ID, "Node parent", null) {}).apply {
             beforeEach(nodeParentBeforeEach)
             afterEach(nodeParentAfterEach)
         }
 
         val nodeAction = mock<Example.() -> Unit>()
-        internal val node = ExampleNode(ID, "Node", SOURCE, null, nodeAction)
+        internal val node = ExampleNode(ID, "Node", null, nodeAction)
 
         init {
             nodeParent.setParent(nodeGrandParent)


### PR DESCRIPTION
* `TestSource` is irrelevant for now.
* Parent groups should be stored in order from top to bottom since `beforeEach` is used more often than `afterEach`.