### PR TITLE
Replace calls with shorter variants.

### DIFF
--- a/conspectus/src/main/kotlin/conspectus/Memoized.kt
+++ b/conspectus/src/main/kotlin/conspectus/Memoized.kt
@@ -8,10 +8,10 @@ class Memoized<out T : Any>(private val creator: () -> T) : ReadOnlyProperty<Any
     private var value: T? = null
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        return value ?: creator.invoke().apply { value = this }
+        return value ?: creator().apply { value = this }
     }
 
-    fun reset() {
+    internal fun reset() {
         value = null
     }
 }

--- a/conspectus/src/main/kotlin/conspectus/engine/Engine.kt
+++ b/conspectus/src/main/kotlin/conspectus/engine/Engine.kt
@@ -74,7 +74,7 @@ internal class Engine : HierarchicalTestEngine<EngineExecutionContext>() {
             val source = ClassSource.from(spec.javaClass)
 
             return ExampleGroupNode(id, name, source).also { node ->
-                spec.action.invoke(node)
+                spec.action(node)
             }
         }
     }

--- a/conspectus/src/main/kotlin/conspectus/engine/ExampleGroupNode.kt
+++ b/conspectus/src/main/kotlin/conspectus/engine/ExampleGroupNode.kt
@@ -38,7 +38,7 @@ internal class ExampleGroupNode(
         val nodeMarker = marker.nested(this.marker)
 
         appendChild(ExampleGroupNode(nodeId, name, null, nodeMarker, action).also {
-            it.action.invoke(it)
+            it.action(it)
         })
     }
 
@@ -75,11 +75,11 @@ internal class ExampleGroupNode(
     }
 
     fun executeBeforeEach() {
-        beforeEachStorage.forEach { it.invoke() }
+        beforeEachStorage.forEach { it() }
     }
 
     fun executeAfterEach() {
-        afterEachStorage.forEach { it.invoke() }
+        afterEachStorage.forEach { it() }
 
         memoizedStorage.forEach { it.reset() }
     }

--- a/conspectus/src/main/kotlin/conspectus/engine/ExampleNode.kt
+++ b/conspectus/src/main/kotlin/conspectus/engine/ExampleNode.kt
@@ -43,7 +43,7 @@ internal class ExampleNode(
     }
 
     override fun execute(context: EngineExecutionContext, dynamicTestExecutor: Node.DynamicTestExecutor): EngineExecutionContext {
-        action.invoke(BlankExample)
+        action(BlankExample)
 
         return context
     }

--- a/conspectus/src/main/kotlin/conspectus/engine/UniqueId.kt
+++ b/conspectus/src/main/kotlin/conspectus/engine/UniqueId.kt
@@ -7,10 +7,10 @@ internal fun UniqueId.childId(type: TestDescriptor.Type, name: String): UniqueId
     val segmentType = when (type) {
         TestDescriptor.Type.CONTAINER -> "c"
         TestDescriptor.Type.TEST -> "t"
-        TestDescriptor.Type.CONTAINER_AND_TEST -> "ct"
+        TestDescriptor.Type.CONTAINER_AND_TEST -> throw IllegalArgumentException("[${type.name}] descriptor is unsupported.")
     }
 
     val segmentValue = name.hashCode().toString()
 
-    return this.append(segmentType, segmentValue)
+    return append(segmentType, segmentValue)
 }


### PR DESCRIPTION
`invoke()` → `()`