### PR TITLE
Add memoized access lock outside of the execution phase.

### DIFF
--- a/conspectus/src/main/kotlin/conspectus/Memoized.kt
+++ b/conspectus/src/main/kotlin/conspectus/Memoized.kt
@@ -6,12 +6,21 @@ import kotlin.reflect.KProperty
 class Memoized<out T : Any>(private val creator: () -> T) : ReadOnlyProperty<Any?, T> {
 
     private var value: T? = null
+    private var enabled: Boolean = false
+
+    internal fun setUp() {
+        value = null
+        enabled = true
+    }
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        check(enabled) { "Memoized value accessed outside of execution actions. This is blocked to avoid state management issues." }
+
         return value ?: creator().apply { value = this }
     }
 
-    internal fun reset() {
+    internal fun tearDown() {
         value = null
+        enabled = false
     }
 }

--- a/conspectus/src/main/kotlin/conspectus/engine/ExampleGroupNode.kt
+++ b/conspectus/src/main/kotlin/conspectus/engine/ExampleGroupNode.kt
@@ -73,12 +73,12 @@ internal class ExampleGroupNode(
     }
 
     fun executeBeforeEach() {
+        memoizedStorage.forEach { it.setUp() }
         beforeEachStorage.forEach { it() }
     }
 
     fun executeAfterEach() {
         afterEachStorage.forEach { it() }
-
-        memoizedStorage.forEach { it.reset() }
+        memoizedStorage.forEach { it.tearDown() }
     }
 }

--- a/conspectus/src/test/kotlin/conspectus/MemoizedSpec.kt
+++ b/conspectus/src/test/kotlin/conspectus/MemoizedSpec.kt
@@ -1,50 +1,46 @@
 package conspectus
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.mockito.Mockito.*
 
 class MemoizedSpec : Spec({
 
     val env by memoized { Environment() }
 
+    it("throws on accessing") {
+        assertThatIllegalStateException().isThrownBy { env.value }
+    }
+
     it("does not call creator") {
         verifyNoInteractions(env.creator)
     }
 
-    context("access") {
+    context("set up") {
 
         beforeEach {
-            env.value
+            env.valueContainer.setUp()
         }
 
-        it("calls creator") {
-            verifyOnly(env.creator).invoke()
+        it("does not call creator") {
+            verifyNoInteractions(env.creator)
         }
 
-        it("returns creator result") {
-            assertThat(env.value).isEqualTo(Environment.CREATOR_RESULT)
-        }
-
-        context("access again") {
+        context("access") {
 
             beforeEach {
-                clearInvocations(env.creator)
-
                 env.value
             }
 
-            it("does not call creator") {
-                verifyNoInteractions(env.creator)
-            }
-        }
-
-        context("reset") {
-
-            beforeEach {
-                env.valueContainer.reset()
+            it("calls creator") {
+                verifyOnly(env.creator).invoke()
             }
 
-            context("access") {
+            it("returns creator result") {
+                assertThat(env.value).isEqualTo(Environment.CREATOR_RESULT)
+            }
+
+            context("access again") {
 
                 beforeEach {
                     clearInvocations(env.creator)
@@ -52,8 +48,55 @@ class MemoizedSpec : Spec({
                     env.value
                 }
 
-                it("calls creator") {
-                    verifyOnly(env.creator).invoke()
+                it("does not call creator") {
+                    verifyNoInteractions(env.creator)
+                }
+
+                it("returns creator result") {
+                    assertThat(env.value).isEqualTo(Environment.CREATOR_RESULT)
+                }
+            }
+
+            context("tear down") {
+
+                beforeEach {
+                    clearInvocations(env.creator)
+
+                    env.valueContainer.tearDown()
+                }
+
+                it("throws on accessing") {
+                    assertThatIllegalStateException().isThrownBy { env.value }
+                }
+
+                it("does not call creator") {
+                    verifyNoInteractions(env.creator)
+                }
+
+                context("set up") {
+
+                    beforeEach {
+                        env.valueContainer.setUp()
+                    }
+
+                    it("does not call creator") {
+                        verifyNoInteractions(env.creator)
+                    }
+
+                    context("access") {
+
+                        beforeEach {
+                            env.value
+                        }
+
+                        it("calls creator") {
+                            verifyOnly(env.creator).invoke()
+                        }
+
+                        it("returns creator result") {
+                            assertThat(env.value).isEqualTo(Environment.CREATOR_RESULT)
+                        }
+                    }
                 }
             }
         }
@@ -62,6 +105,7 @@ class MemoizedSpec : Spec({
 }) {
 
     class Environment {
+
         companion object {
             const val CREATOR_RESULT = "value"
         }


### PR DESCRIPTION
```kotlin
val stateful = mock<Stateful>()

beforeEach {
    stateful.call()
}
```

This kind of code will not reset the mock between tests so it will continue to collect calls. In fact, this issue is related to everything state-related.