### PR TITLE
Update JUnit Platform 1.5.2 → 1.6.0.

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ enum class Library(group: String, artifact: String, internal val version: Versio
 
     internal enum class Version(val value: String) {
         AssertJ("3.14.0"),
-        JUnitPlatform("1.5.2"),
+        JUnitPlatform("1.6.0"),
         Kotlin("1.3.60"),
         Mockito("3.1.0"),
     }

--- a/conspectus/src/test/kotlin/conspectus/engine/IntegrationSpec.kt
+++ b/conspectus/src/test/kotlin/conspectus/engine/IntegrationSpec.kt
@@ -27,7 +27,7 @@ class IntegrationSpec : Spec({
                 event(engine(), finishedSuccessfully())
         )
 
-        all().assertEventsMatchExactly(*engineEvents)
+        allEvents().assertEventsMatchExactly(*engineEvents)
     }
 
     mapOf(MarkedSpec.CLASS to MarkedSpec.EVENTS, NestedSpec.CLASS to NestedSpec.EVENTS).forEach { (specClass, specEvents) ->


### PR DESCRIPTION
[The changelog](https://junit.org/junit5/docs/5.6.0/release-notes/index.html#release-notes-5.6.0-junit-platform).